### PR TITLE
Facelifting and simplifying logging

### DIFF
--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/handler/MotrWebHandler.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/handler/MotrWebHandler.java
@@ -9,9 +9,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import uk.gov.dvsa.motr.web.config.Config;
 import uk.gov.dvsa.motr.web.system.MotrWebApplication;
 
-import static uk.gov.dvsa.motr.web.accesslog.AccessLogger.logAccess;
-import static uk.gov.dvsa.motr.web.system.LogConfigurator.configureLogging;
-import static uk.gov.dvsa.motr.web.system.LogConfigurator.setRequestContext;
+import static uk.gov.dvsa.motr.web.logging.LambdaInvocationLogging.invokeWithLogging;
+import static uk.gov.dvsa.motr.web.logging.LogConfigurator.configureLogging;
 
 
 /**
@@ -34,7 +33,6 @@ public class MotrWebHandler implements RequestHandler<AwsProxyRequest, AwsProxyR
 
     public AwsProxyResponse handleRequest(AwsProxyRequest request, Context context) {
 
-        setRequestContext(context);
-        return logAccess(request, context, handler::proxy);
+        return invokeWithLogging(request, context, handler::proxy);
     }
 }

--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/logging/LambdaInvocationLogging.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/logging/LambdaInvocationLogging.java
@@ -1,4 +1,4 @@
-package uk.gov.dvsa.motr.web.accesslog;
+package uk.gov.dvsa.motr.web.logging;
 
 import com.amazonaws.serverless.proxy.internal.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.internal.model.AwsProxyResponse;
@@ -15,11 +15,11 @@ import java.util.function.BiFunction;
 /**
  * Logs request/response information about handling proxy event
  */
-public class AccessLogger {
+public class LambdaInvocationLogging {
 
-    private static final Logger logger = LoggerFactory.getLogger(AccessLogger.class.getSimpleName());
+    private static final Logger logger = LoggerFactory.getLogger("AccessLogger");
 
-    public static AwsProxyResponse logAccess(
+    public static AwsProxyResponse invokeWithLogging(
             AwsProxyRequest request,
             Context ctx,
             BiFunction<AwsProxyRequest, Context, AwsProxyResponse> handler
@@ -30,25 +30,31 @@ public class AccessLogger {
         fields.put("request.method", request.getHttpMethod());
         fields.put("request.path", request.getPath());
         fields.put("request.queryString", request.getQueryString());
+        MDC.put("lambdaFunction", ctx.getFunctionName() + ":" + ctx.getFunctionVersion());
 
         try {
 
             AwsProxyResponse response = handler.apply(request, ctx);
+
             fields.put("response.statusCode", String.valueOf(response.getStatusCode()));
             fields.put("response.body.length", response.getBody().length());
 
-            fields.forEach((key, val) -> MDC.put(key, val.toString()));
-
+            copyToMdc(fields);
             logger.info("Access event");
 
             return response;
         } catch (Exception e) {
 
+            copyToMdc(fields);
             logger.error("Access error", e);
+
             throw e;
         } finally {
-
             fields.forEach((key, val) -> MDC.remove(key));
         }
+    }
+
+    private static void copyToMdc(Map<String, Object> fields) {
+        fields.forEach((key, val) -> MDC.put(key, val.toString()));
     }
 }

--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/logging/LogConfigurator.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/logging/LogConfigurator.java
@@ -1,8 +1,4 @@
-package uk.gov.dvsa.motr.web.system;
-
-import com.amazonaws.services.lambda.runtime.Context;
-
-import org.slf4j.MDC;
+package uk.gov.dvsa.motr.web.logging;
 
 import uk.gov.dvsa.motr.web.config.Config;
 
@@ -22,9 +18,5 @@ public class LogConfigurator {
 
         String logLevel = config.getValue(LOG_LEVEL).orElse(DEFAULT_LOG_LEVEL);
         getRootLogger().setLevel(toLevel(logLevel));
-    }
-
-    public static void setRequestContext(Context context) {
-        MDC.put("lambdaFunctionName", context.getFunctionName());
     }
 }


### PR DESCRIPTION
Have cleaned up Lambda logging setup for the  request. Function name which is part of MDC is now part of LambdaInvocationLogging which makes more sense rather than separate method on LogConfigurator.