### PR TITLE
DynamoDB does not require connection string. Access can be driven off…

### DIFF
--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/system/SystemVariable.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/system/SystemVariable.java
@@ -6,7 +6,6 @@ public enum SystemVariable implements ConfigKey {
 
     LOG_LEVEL("LOG_LEVEL"),
     REGION("REGION"),
-    DB_CONNECTION_STRING("DB_CONNECTION_STRING"),
     GOV_NOTIFY_URI("GOV_NOTIFY_URI"),
     // must be secret
     GOV_NOTIFY_API_TOKEN("GOV_NOTIFY_API_TOKEN"),


### PR DESCRIPTION
… IAM roles