### PR TITLE
Add reason for cancellation to web app

### DIFF
--- a/webapp/src/integration-test/java/uk/gov/dvsa/motr/web/component/subscription/persistence/DynamoDbCancelledSubscriptionRepositoryTest.java
+++ b/webapp/src/integration-test/java/uk/gov/dvsa/motr/web/component/subscription/persistence/DynamoDbCancelledSubscriptionRepositoryTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import uk.gov.dvsa.motr.test.integration.dynamodb.fixture.core.DynamoDbFixture;
 import uk.gov.dvsa.motr.test.integration.dynamodb.fixture.model.CancelledSubscriptionItem;
 import uk.gov.dvsa.motr.web.component.subscription.model.CancelledSubscription;
+import uk.gov.dvsa.motr.web.component.subscription.service.UnsubscribeService;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -20,6 +21,8 @@ import static uk.gov.dvsa.motr.test.integration.dynamodb.DynamoDbIntegrationHelp
 import static uk.gov.dvsa.motr.test.integration.dynamodb.DynamoDbIntegrationHelper.region;
 
 public class DynamoDbCancelledSubscriptionRepositoryTest {
+
+    private static final String REASON_FOR_CANCELLATION_USER_CANCELLED = "User cancelled";
 
     CancelledSubscriptionRepository repository;
     DynamoDbFixture fixture;
@@ -41,7 +44,8 @@ public class DynamoDbCancelledSubscriptionRepositoryTest {
                 .setUnsubscribeId(cancelledSubscriptionItem.getUnsubscribeId())
                 .setEmail(cancelledSubscriptionItem.getEmail())
                 .setVrm(cancelledSubscriptionItem.getVrm())
-                .setMotTestNumber(cancelledSubscriptionItem.getMotTestNumber());
+                .setMotTestNumber(cancelledSubscriptionItem.getMotTestNumber())
+                .setReasonForCancellation(REASON_FOR_CANCELLATION_USER_CANCELLED);
 
         repository.save(cancelledSubscription);
 

--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/model/CancelledSubscription.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/model/CancelledSubscription.java
@@ -9,6 +9,8 @@ public class CancelledSubscription {
 
     private String motTestNumber;
 
+    private String reasonForCancellation;
+
     public String getUnsubscribeId() {
         return unsubscribeId;
     }
@@ -29,6 +31,15 @@ public class CancelledSubscription {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getReasonForCancellation() {
+        return reasonForCancellation;
+    }
+
+    public CancelledSubscription setReasonForCancellation(String reasonForCancellation) {
+        this.reasonForCancellation = reasonForCancellation;
+        return this;
     }
 
     public CancelledSubscription setEmail(String email) {

--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/persistence/DynamoDbCancelledSubscriptionRepository.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/persistence/DynamoDbCancelledSubscriptionRepository.java
@@ -38,6 +38,7 @@ public class DynamoDbCancelledSubscriptionRepository implements CancelledSubscri
                 .withString("id", cancelledSubscription.getUnsubscribeId())
                 .withString("vrm", cancelledSubscription.getVrm())
                 .withString("email", cancelledSubscription.getEmail())
+                .withString("reason_for_cancellation", cancelledSubscription.getReasonForCancellation())
                 .withString("cancelled_at", ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT));
 
         dynamoDb.getTable(tableName).putItem(item);

--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/service/UnsubscribeService.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/component/subscription/service/UnsubscribeService.java
@@ -15,6 +15,8 @@ import javax.ws.rs.NotFoundException;
 
 public class UnsubscribeService {
 
+    private static final String REASON_FOR_CANCELLATION_USER_CANCELLED = "User cancelled";
+
     private SubscriptionRepository subscriptionRepository;
     private CancelledSubscriptionRepository cancelledSubscriptionRepository;
 
@@ -40,6 +42,7 @@ public class UnsubscribeService {
                     .setVrm(sub.getVrm())
                     .setEmail(sub.getEmail())
                     .setDueDate(sub.getMotDueDate())
+                    .setReasonForCancellation(REASON_FOR_CANCELLATION_USER_CANCELLED)
             );
 
             return sub;
@@ -57,6 +60,7 @@ public class UnsubscribeService {
         return new CancelledSubscription()
                 .setUnsubscribeId(subscription.getUnsubscribeId())
                 .setVrm(subscription.getVrm())
-                .setEmail(subscription.getEmail());
+                .setEmail(subscription.getEmail())
+                .setReasonForCancellation(REASON_FOR_CANCELLATION_USER_CANCELLED);
     }
 }

--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/eventlog/subscription/SubscriptionEvent.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/eventlog/subscription/SubscriptionEvent.java
@@ -24,4 +24,9 @@ public abstract class SubscriptionEvent extends Event {
         params.put("mot-due-date", motDueDate.format(DateTimeFormatter.ISO_DATE));
         return this;
     }
+
+    public SubscriptionEvent setReasonForCancellation(String reasonForCancellation) {
+        params.put("reason_for_cancellation", reasonForCancellation);
+        return this;
+    }
 }


### PR DESCRIPTION
After adding the Lambda for unsubscribing permanently failing notifications,
we need to save the fact that unsubscriptions from the web app are
user-directed.