### PR TITLE
GOV.UK style changes

### DIFF
--- a/webapp/src/main/resources/template/vrm.hbs
+++ b/webapp/src/main/resources/template/vrm.hbs
@@ -1,7 +1,7 @@
 {{#partial "content" }}
     <header class="content-header">
         <h1 class="content-header__title">
-            What is the vehicle's registration (number plate)?
+            Enter the vehicle's number plate (registration)
         </h1>
     </header>
 
@@ -17,7 +17,7 @@
 
         <div class="form-group {{#message}}has-error{{/message}}">
             <label for="regNumber" class="form-label">
-                Registration (number plate)
+                Number plate (registration)
             </label>
             {{#showInLine}}
                 <span class="validation-message">{{message}}</span>
@@ -39,4 +39,4 @@
     </form>
 
 {{/partial}}
-{{> master pageTitle="What is the vehicle’s registration (number plate)? – MOT reminders"}}
+{{> master pageTitle="Enter the vehicle's number plate (registration) – MOT reminders"}}


### PR DESCRIPTION
Text changes to meet GOV.UK style guide. Call the registration 'number plate (registration').