### PR TITLE
Use typographic apostrophes

### DIFF
--- a/selenium/src/main/java/uk/gov/dvsa/motr/ui/page/VrmPage.java
+++ b/selenium/src/main/java/uk/gov/dvsa/motr/ui/page/VrmPage.java
@@ -17,13 +17,13 @@ public class VrmPage extends Page {
     @Override
     protected String getContentHeader() {
 
-        return "What is the vehicle's registration number?";
+        return "What is the vehicle’s registration number?";
     }
 
     @Override
     protected String getPageTitle() {
 
-        return "What is the vehicle's registration number? – MOT reminders";
+        return "What is the vehicle’s registration number? – MOT reminders";
     }
 
     public EmailPage enterVrm(String vrm){

--- a/webapp/src/main/java/uk/gov/dvsa/motr/web/validator/VrmValidator.java
+++ b/webapp/src/main/java/uk/gov/dvsa/motr/web/validator/VrmValidator.java
@@ -4,7 +4,7 @@ import java.util.regex.Pattern;
 
 public class VrmValidator {
 
-    public static final String REGISTRATION_EMPTY_MESSAGE = "Enter the vehicle's registration";
+    public static final String REGISTRATION_EMPTY_MESSAGE = "Enter the vehicle’s registration";
     public static final String REGISTRATION_TOO_LONG_MESSAGE = "Registration must be shorter than 14 characters";
     public static final String REGISTRATION_CAN_ONLY_CONTAIN_LETTERS_NUMBERS_AND_HYPHENS_MESSAGE = "Registration can only contain " +
             "letters, numbers and hyphens";

--- a/webapp/src/main/resources/template/home.hbs
+++ b/webapp/src/main/resources/template/home.hbs
@@ -24,7 +24,7 @@
             <p>You'll need:</p>
 
             <ul class="list-bullet u-space-b15">
-                <li>your vehicle's registration number</li>
+                <li>your vehicle’s registration number</li>
                 <li>an email address {{#if featureToggleSms}}or a mobile phone number{{/if}}</li>
             </ul>
 
@@ -41,7 +41,7 @@
             <a href="https://www.gov.uk/call-charges">Find out about call charges</a>
 
         </div>
-        
+
         <div class="column-third">
 
             <aside class="govuk-related-items">

--- a/webapp/src/main/resources/template/terms-and-conditions.hbs
+++ b/webapp/src/main/resources/template/terms-and-conditions.hbs
@@ -47,7 +47,7 @@
             permission if you want to either:</p>
 
         <ul class="list-bullet">
-            <li>charge your website's users to click on a link to any page on MOT
+            <li>charge your website’s users to click on a link to any page on MOT
                 reminders
             </li>
             <li>say your website is associated with or endorsed by the service or
@@ -104,7 +104,7 @@
             under the OGL, we'll usually credit the author or copyright holder.</p>
 
         <p>You can reproduce content published on MOT reminders under the OGL
-            as long as you follow the licence's conditions.</p>
+            as long as you follow the licence’s conditions.</p>
 
         <p><a rel="external"
               href="https://www.gov.uk/contact-dvsa"
@@ -112,7 +112,7 @@
             Contact us
         </a>
             if you want to reproduce a piece of content but aren't sure if
-            it's covered by Crown copyright or the OGL.</p>
+            it’s covered by Crown copyright or the OGL.</p>
 
         <p>We make most of the content on MOT reminders available through feeds
             for other websites and applications to use. The websites and
@@ -223,11 +223,11 @@
 
         <h2 class="heading-medium">Viruses, hacking and other offences</h2>
         <p>When using MOT reminders, you must not introduce viruses, trojans,
-            worms, logic bombs or any other material that's malicious or
+            worms, logic bombs or any other material that’s malicious or
             technologically harmful.</p>
 
         <p>You must not try to gain unauthorised access to MOT reminders, the
-            server on which it's stored or any server, computer or database
+            server on which it’s stored or any server, computer or database
             connected to it.</p>
 
         <p>You must not attack MOT reminder in any way. This includes

--- a/webapp/src/main/resources/template/vrm.hbs
+++ b/webapp/src/main/resources/template/vrm.hbs
@@ -6,7 +6,7 @@
 
             <a href="{{{url this back_url}}}" class="link-back">{{back_button_text}}</a>
 
-            <h1 class="heading-xlarge">What is the vehicle's registration number?</h1>
+            <h1 class="heading-xlarge">What is the vehicle’s registration number?</h1>
 
             {{#message}}
                 {{> partial/error-message }}
@@ -40,4 +40,4 @@
     </div>
 
 {{/partial}}
-{{> master pageTitle="What is the vehicle's registration number? – MOT reminders"}}
+{{> master pageTitle="What is the vehicle’s registration number? – MOT reminders"}}

--- a/webapp/src/test/java/uk/gov/dvsa/motr/web/validator/VrmValidatorTest.java
+++ b/webapp/src/test/java/uk/gov/dvsa/motr/web/validator/VrmValidatorTest.java
@@ -20,7 +20,7 @@ public class VrmValidatorTest {
         VrmValidator vrmValidator = new VrmValidator();
 
         assertFalse(vrmValidator.isValid(null));
-        assertEquals("Enter the vehicle's registration", vrmValidator.getMessage());
+        assertEquals("Enter the vehicle’s registration", vrmValidator.getMessage());
     }
 
     @Test


### PR DESCRIPTION
> “Smart quotes,” the correct quotation marks and apostrophes, are curly or sloped. "Dumb quotes," or straight quotes, are a vestigial constraint from typewriters when using one key for two different marks helped save space on a keyboard. Unfortunately, many improper marks make their way onto websites because of dumb defaults in applications and CMSs.

– http://smartquotesforsmartpeople.com/

This commit replaces all instances of straight single quotes used as apostrophes (') with the unicode character for a proper typographic apostrophe (’).

---

Your service is great by the way, nice work 👍